### PR TITLE
create versioned symlinks for non-wide libs

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,9 +50,10 @@ fi
 # Make symlinks from the wide to the non-wide libraries.
 pushd "${PREFIX}"/lib
   for _LIB in ncurses ncurses++ form panel menu tinfo; do
-    if [[ -f lib${_LIB}w${_SOEXT} ]]; then
-      ln -s lib${_LIB}w${_SOEXT} lib${_LIB}${_SOEXT}
-    fi
+    for WIDE_LIBFILE in $(ls lib${_LIB}w${_SOEXT}*); do
+      NONWIDE_LIBFILE=${WIDE_LIBFILE/${_LIB}w/${_LIB}}
+      ln -s ${WIDE_LIBFILE} ${NONWIDE_LIBFILE}
+    done
     if [[ -f lib${_LIB}w.a ]]; then
       ln -s lib${_LIB}w.a lib${_LIB}.a
     fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 0
+  number: 1
   run_exports:
     # pretty good compat within major version
     #  https://abi-laboratory.pro/tracker/timeline/ncurses/


### PR DESCRIPTION
Create symlinks from the versioned and un-versioned wide libraries to the
non-wide libraries.

Previously only un-versioned symlinks were created.