### PR TITLE
Update dependencies, source/url, and add sha256

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,6 +23,8 @@ if [[ ${LDFLAGS} =~ $re ]]; then
   export LDFLAGS="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
 fi
 
+export PKG_CONFIG_LIBDIR="${BUILD_PREFIX}"/lib/pkgconfig
+
 ./configure \
   --prefix="${PREFIX}" \
   --without-debug \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -46,7 +46,7 @@ else
 fi
 
 # Make symlinks from the wide to the non-wide libraries.
-pushd "${PREFIX}"/lib
+pushd "${BUILD_PREFIX}"/lib
   for _LIB in ncurses ncurses++ form panel menu tinfo; do
     for WIDE_LIBFILE in $(ls lib${_LIB}w${_SOEXT}*); do
       NONWIDE_LIBFILE=${WIDE_LIBFILE/${_LIB}w/${_LIB}}
@@ -83,7 +83,7 @@ done
 
 # Ensure that the code at the top that strips -L and -Wl,-rpath from LDFLAGS did its job
 # and we have ended up with a working ncursesw.pc file (i.e. one that contains -ltinfow)
-if ! cat "${PREFIX}"/lib/pkgconfig/ncursesw.pc | grep "Libs:" | grep "\-ltinfow"; then
+if ! cat "${BUILD_PREFIX}"/lib/pkgconfig/ncursesw.pc | grep "Libs:" | grep "\-ltinfow"; then
   echo "ERROR: ncurses gen-pkgconfig script has created a broken ncursesw.pc"
   echo "       It does not contain '-ltinfow' in the 'Libs:' line"
   exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -x -u
 
 # ncurses (gen-pkgconfig.in) adds -ltinfo to ncurses.pc if any of the following conditions is true:
 # 1. No `*-Wl,-rpath,*` is found in EXTRA_LDFLAGS
@@ -25,8 +25,6 @@ fi
 
 ./configure \
   --prefix="${PREFIX}" \
-  --build=${BUILD} \
-  --host=${HOST} \
   --without-debug \
   --without-ada \
   --without-manpages \
@@ -34,7 +32,7 @@ fi
   --disable-overwrite \
   --enable-symlinks \
   --enable-termcap \
-  --with-pkg-config-libdir="${PREFIX}"/lib/pkgconfig \
+  --with-pkg-config-libdir="${BUILD_PREFIX}"/lib/pkgconfig \
   --enable-pc-files \
   --with-termlib \
   --enable-widec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
   fn: ncurses-{{ version }}.tar.gz
   url: https://invisible-mirror.net/archives/ncurses/ncurses-{{ version }}.tar.gz
   sha256: 97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059
+  patches:
+    - fix.patch
+    - clang.patch
 
 build:
   skip: True  # [win]
@@ -22,6 +25,7 @@ requirements:
     - {{ compiler('c') }}
     - pkg-config
     - make
+    - patch
 
 test:
 # TODO :: conda-build needs seperate test/requires_build and test/requires_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,8 @@ package:
 
 source:
   fn: ncurses-{{ version }}.tar.gz
-  url: https://github.com/mirror/ncurses/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: dbab3d9f3b59fc5c3887ce72bafd83b9245edc198c53df8014ca0afaa16c5cd5
-  patches:
-    # http://lists.gnu.org/archive/html/bug-ncurses/2011-04/txtkWQqiQvcZe.txt
-    - fix.patch
-    # http://lists.gnu.org/archive/html/bug-ncurses/2015-01/msg00016.html
-    #- ncurses-5.9-gcc-5.patch
-    - clang.patch
+  url: https://invisible-mirror.net/archives/ncurses/ncurses-{{ version }}.tar.gz
+  sha256: 97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059
 
 build:
   skip: True  # [win]
@@ -26,10 +20,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - pkg-config
     - make
-    - patch
 
 test:
 # TODO :: conda-build needs seperate test/requires_build and test/requires_host

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.2" %}
+{% set version = "6.3" %}
 
 package:
   name: ncurses
@@ -6,13 +6,13 @@ package:
 
 source:
   fn: ncurses-{{ version }}.tar.gz
-  url: http://ftp.gnu.org/pub/gnu/ncurses/ncurses-{{ version }}.tar.gz
-  md5: e812da327b1c2214ac1aed440ea3ae8d
+  url: https://github.com/mirror/ncurses/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: dbab3d9f3b59fc5c3887ce72bafd83b9245edc198c53df8014ca0afaa16c5cd5
   patches:
     # http://lists.gnu.org/archive/html/bug-ncurses/2011-04/txtkWQqiQvcZe.txt
     - fix.patch
     # http://lists.gnu.org/archive/html/bug-ncurses/2015-01/msg00016.html
-    - ncurses-5.9-gcc-5.patch
+    #- ncurses-5.9-gcc-5.patch
     - clang.patch
 
 build:
@@ -26,8 +26,10 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - pkg-config
     - make
+    - patch
 
 test:
 # TODO :: conda-build needs seperate test/requires_build and test/requires_host


### PR DESCRIPTION
Update to 6.3

Actions:
1. Update source/url. The old one hasn't the release v6.3
2. Add sha256 and remove md5
3. Disable patches `ncurses-5.9-gcc-5.patch`, `fix.patch`, and `clang.patch`
4. Update build.sh: add `PKG_CONFIG_LIBDIR `and change `"${PREFIX}"` to` "${BUILD_PREFIX}"`

