### PR TITLE
Apply patch for CVE-2022-29458

### DIFF
--- a/recipe/CVE-2022-29458.patch
+++ b/recipe/CVE-2022-29458.patch
@@ -1,0 +1,51 @@
+diff --git a/ncurses/tinfo/read_entry.c b/ncurses/tinfo/read_entry.c
+index 41ef0d0aa..66e3d31ee 100644
+--- a/ncurses/tinfo/read_entry.c
++++ b/ncurses/tinfo/read_entry.c
+@@ -1,5 +1,5 @@
+ /****************************************************************************
+- * Copyright 2018-2020,2021 Thomas E. Dickey                                *
++ * Copyright 2018-2021,2022 Thomas E. Dickey                                *
+  * Copyright 1998-2016,2017 Free Software Foundation, Inc.                  *
+  *                                                                          *
+  * Permission is hereby granted, free of charge, to any person obtaining a  *
+@@ -42,7 +42,7 @@
+ 
+ #include <tic.h>
+ 
+-MODULE_ID("$Id: read_entry.c,v 1.161 2021/06/26 19:43:17 tom Exp $")
++MODULE_ID("$Id: read_entry.c,v 1.162 2022/04/16 21:00:00 tom Exp $")
+ 
+ #define TYPE_CALLOC(type,elts) typeCalloc(type, (unsigned)(elts))
+ 
+@@ -145,6 +145,7 @@ convert_strings(char *buf, char **Strings, int count, int size, char *table)
+ {
+     int i;
+     char *p;
++    bool corrupt = FALSE;
+ 
+     for (i = 0; i < count; i++) {
+ 	if (IS_NEG1(buf + 2 * i)) {
+@@ -154,8 +155,20 @@ convert_strings(char *buf, char **Strings, int count, int size, char *table)
+ 	} else if (MyNumber(buf + 2 * i) > size) {
+ 	    Strings[i] = ABSENT_STRING;
+ 	} else {
+-	    Strings[i] = (MyNumber(buf + 2 * i) + table);
+-	    TR(TRACE_DATABASE, ("Strings[%d] = %s", i, _nc_visbuf(Strings[i])));
++	    int nn = MyNumber(buf + 2 * i);
++	    if (nn >= 0 && nn < size) {
++		Strings[i] = (nn + table);
++		TR(TRACE_DATABASE, ("Strings[%d] = %s", i,
++				    _nc_visbuf(Strings[i])));
++	    } else {
++		if (!corrupt) {
++		    corrupt = TRUE;
++		    TR(TRACE_DATABASE,
++		       ("ignore out-of-range index %d to Strings[]", nn));
++		    _nc_warning("corrupt data found in convert_strings");
++		}
++		Strings[i] = ABSENT_STRING;
++	    }
+ 	}
+ 
+ 	/* make sure all strings are NUL terminated */

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,10 @@ if [[ $target_platform =~ osx-.* ]]; then
     export cf_cv_mixedcase=no
 fi
 
+if [ ! -f "${BUILD_PREFIX}/bin/strip" ]; then
+    ln -sf "${HOST}-strip" "${BUILD_PREFIX}/bin/strip"
+fi
+
 export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig
 
 ./configure \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,11 @@ source:
     # http://lists.gnu.org/archive/html/bug-ncurses/2011-04/txtkWQqiQvcZe.txt
     - fix.patch
     - clang.patch
+    - CVE-2022-29458.patch
 
 build:
   skip: True  # [win]
-  number: 2
+  number: 3
   run_exports:
     # pretty good compat within major version
     #  https://abi-laboratory.pro/tracker/timeline/ncurses/


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2022-29458. Was cherry-picked from https://github.com/mirror/ncurses/commit/4c9f63c460cb7134f142aa65f6866c175ed77605 because the commit itself contains many changes, and we only need the patch for the CVE fix.